### PR TITLE
Enable working bundler groups

### DIFF
--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -2,10 +2,7 @@ FROM ruby:3.1-alpine3.16 AS builder
 
 ADD src/Gemfile* .
 RUN apk upgrade && \
-    apk add --no-cache \
-      g++ \
-      make && \
-    bundle config set with api && \
+    apk add --no-cache g++ make && \
     bundle install
 
 FROM ruby:3.1-alpine3.16
@@ -36,6 +33,9 @@ USER ruby
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
 ADD --chown=ruby:ruby src/ $APP_HOME/
+
+# Grab generated Gemfile.lock from builder. This will allow bundle exec to run without running bundle install again.
+COPY --from=builder --chown=ruby:ruby Gemfile.lock $APP_HOME/Gemfile.lock
 
 EXPOSE 59999
 

--- a/provider.Dockerfile
+++ b/provider.Dockerfile
@@ -1,10 +1,10 @@
 FROM ruby:3.1-alpine3.16 AS builder
 
+ENV BUNDLE_WITHOUT api
+
 ADD src/Gemfile* .
 RUN apk upgrade && \
-    apk add --no-cache \
-      g++ \
-      make && \
+    apk add --no-cache g++ make && \
     bundle install
 
 FROM ruby:3.1-alpine3.16
@@ -35,7 +35,10 @@ COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
 ADD --chown=ruby:ruby src/ $APP_HOME/
 
+# Grab generated Gemfile.lock from builder. This will allow bundle exec to run without running bundle install again.
+COPY --from=builder --chown=ruby:ruby Gemfile.lock $APP_HOME/Gemfile.lock
+
 VOLUME $APP_CONFIG_DIR
 
-ENV BUNDLER_WITHOUT api
+ENV BUNDLE_WITHOUT api
 CMD ["bundle", "exec", "ruby", "./provider.rb" ]

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -1,10 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'activesupport'
-gem 'docker-api'
+gem 'activesupport', '~> 7.0'
+gem 'docker-api', '~> 2.2'
 
-# group :api, optional: true do
-  gem 'sinatra'
-  gem 'sinatra-contrib'
-  gem 'puma'
-# end
+group :api do
+  gem 'sinatra', '~> 2.2'
+  gem 'sinatra-contrib', '~> 2.2'
+  gem 'puma', '~> 5.6'
+end


### PR DESCRIPTION
I made the `api` group default on because well I think doing a `bundle install` for development should just install everything, but it'd be easy to go the other way as well. But yeah, I think this should work?